### PR TITLE
Add weighted random selection for character generator

### DIFF
--- a/other-projects/character-creator/character_generator.js
+++ b/other-projects/character-creator/character_generator.js
@@ -38,7 +38,24 @@ function getFiltered(data, field, allowedId) {
   });
 }
 
-function getRandomFrom(array) {
+function getRandomFrom(array, weightProp) {
+  if (!Array.isArray(array) || array.length === 0) return undefined;
+
+  if (weightProp) {
+    const weights = array.map(item => parseFloat(item[weightProp]) || 0);
+    const totalWeight = weights.reduce((sum, w) => sum + w, 0);
+
+    if (totalWeight > 0) {
+      let rand = Math.random() * totalWeight;
+      for (let i = 0; i < array.length; i++) {
+        rand -= weights[i];
+        if (rand <= 0) {
+          return array[i];
+        }
+      }
+    }
+  }
+
   return array[Math.floor(Math.random() * array.length)];
 }
 
@@ -61,12 +78,12 @@ function generateCharacter() {
   const agegroups = state.dataPool.agegroups;
 
   const agegroup = getRandomFrom(agegroups);
-  const race = getRandomFrom(races);
+  const race = getRandomFrom(races, 'weight');
   const occupation = getRandomFrom(occupations);
   const background = getRandomFrom(backgrounds);
-  const firstName = getRandomFrom(fnames);
-  const lastName = getRandomFrom(lnames);
-  const selectedTraits = Array.from({ length: 3 }, () => getRandomFrom(traits));
+  const firstName = getRandomFrom(fnames, 'weight');
+  const lastName = getRandomFrom(lnames, 'weight');
+  const selectedTraits = Array.from({ length: 3 }, () => getRandomFrom(traits, 'weight'));
 
   if (!firstName || !lastName) {
     alert("No valid names found for this genre and gender. Please check your fnames/lnames.json.");


### PR DESCRIPTION
## Summary
- extend `getRandomFrom` utility to support weighting
- apply weight-based selection when choosing first/last names, races, and traits

## Testing
- `node - <<'NODE'
function getRandomFrom(array, weightProp) {
  if (!Array.isArray(array) || array.length === 0) return undefined;
  if (weightProp) {
    const weights = array.map(item => parseFloat(item[weightProp]) || 0);
    const totalWeight = weights.reduce((sum, w) => sum + w, 0);
    if (totalWeight > 0) {
      let rand = Math.random() * totalWeight;
      for (let i = 0; i < array.length; i++) {
        rand -= weights[i];
        if (rand <= 0) return array[i];
      }
    }
  }
  return array[Math.floor(Math.random() * array.length)];
}
const arr = [{name:'a', weight:1}, {name:'b', weight:9}];
let counts = {a:0,b:0};
for (let i=0;i<1000;i++) counts[getRandomFrom(arr,'weight').name]++;
console.log(counts);
NODE

------
https://chatgpt.com/codex/tasks/task_e_6883e56f021c83318400d266267671d2